### PR TITLE
Add initial version of scraper

### DIFF
--- a/scripts/scraper.R
+++ b/scripts/scraper.R
@@ -45,18 +45,17 @@ download.file(ctv_url, output_file)
 # Read the CTV file and extract package names
 pkgs <- ctv::read.ctv("Epidemiology.md") |>
   purrr::pluck("packagelist", "name") |>
-  pkgsearch::cran_packages() |>
   tail(3)
 
 owner <- "cran"
 
 # Vectorized approach to get title and description of each package
-apply(pkgs, 1, FUN = function(pkg) {
+lapply(pkgs, FUN = function(pkg) {
   # Use the gh function to list all files in the repository
   files <- gh::gh(
     "GET /repos/:owner/:repo/git/trees/HEAD?recursive=1",
     owner = owner,
-    repo = pkg$Package
+    repo = pkg
   )
 
   # Extract the file paths
@@ -71,13 +70,13 @@ apply(pkgs, 1, FUN = function(pkg) {
     for (i in seq_along(matching_files)) {
       if (files$tree[matched_regex][[i]]$type == "blob") {
         file_info <- files$tree[matched_regex][[i]]
-        target_path <- sprintf("sources/%s/%s", pkg$Package, file_info$path)
+        target_path <- sprintf("sources/%s/%s", pkg, file_info$path)
 
         # Use the gh function to get the blob content
         blob <- gh::gh(
           "GET /repos/:owner/:repo/git/blobs/:sha",
           owner = owner,
-          repo = pkg$Package,
+          repo = pkg,
           sha = file_info$sha
         )
 

--- a/scripts/scraper.R
+++ b/scripts/scraper.R
@@ -1,0 +1,111 @@
+library(pkgsearch)
+library(gh)
+
+## Helper function to ensure dirs exist
+write_content_to_file <- function(content, file_path, is_binary = FALSE) {
+  dir_path <- dirname(file_path)
+
+  # If dir doesn't exist, create it
+  if (!dir.exists(dir_path)) {
+    dir.create(dir_path, recursive = TRUE)
+  }
+
+  # Write the content to the file while checking for binaryness
+  if (is_binary) {
+    writeBin(content, file_path)
+  } else {
+    writeLines(rawToChar(content), file_path)
+  }
+}
+
+# Helper function to determine if file extension indicates binary
+is_binary_file <- function(file_path) {
+  binary_extensions <- c(
+    "png",
+    "jpg",
+    "jpeg",
+    "gif",
+    "pdf",
+    "zip",
+    "tar",
+    "gz",
+    "bz2",
+    "xz",
+    "exe",
+    "dll",
+    "bin"
+  )
+  file_ext <- tools::file_ext(file_path)
+  return(file_ext %in% binary_extensions)
+}
+
+# Define the URL and output file path
+ctv_url <- "https://raw.githubusercontent.com/cran-task-views/Epidemiology/main/Epidemiology.md"
+output_file <- "Epidemiology.md"
+
+# Download the file from the URL and save it to the specified path
+download.file(ctv_url, output_file)
+
+# Read the CTV file and extract package names
+pkgs <- read.ctv("Epidemiology.md") |>
+  pluck("packagelist", "name") |>
+  pkgsearch::cran_packages() |> 
+  head(3)
+
+owner <- "cran"
+
+# Vectorized approach to get title and description of each package
+apply(pkgs, 1, FUN = function(pkg) {
+  # Use the gh function to list all files in the repository
+  files <- gh::gh(
+    "GET /repos/:owner/:repo/git/trees/HEAD?recursive=1",
+    owner = owner,
+    repo = pkg$Package
+  )
+
+  # Extract the file paths
+  file_paths <- vapply(files$tree, function(x) x$path, character(1))
+
+  # Find the file that matches the target path
+  matched_regex <- grep(file_paths, pattern = "^(man/|vignettes/)")
+  matching_files <- file_paths[matched_regex]
+
+  # If matching files are found, download content of each file
+  if (length(matching_files) > 0) {
+    for (i in seq_along(matching_files)) {
+      if (files$tree[matched_regex][[i]]$type == "blob") {
+        file_info <- files$tree[matched_regex][[i]]
+        target_path <- sprintf("sources/%s/%s", pkg$Package, file_info$path)
+
+        # Use the gh function to get the blob content
+        blob <- gh::gh(
+          "GET /repos/:owner/:repo/git/blobs/:sha",
+          owner = owner,
+          repo = pkg$Package,
+          sha = file_info$sha
+        )
+
+        # Decode the base64 content
+        file_content <- base64enc::base64decode(blob$content)
+
+        # Determine if the file should be written as binary
+        is_binary <- is_binary_file(target_path)
+
+        # Save the content to a file with our helper function
+        # The helper ensures the paths exist prior to saving
+        tryCatch(write_content_to_file(file_content, target_path, is_binary),
+          error = function(e) {
+            cat("Error downloading or saving file:", target_path, "\n")
+            cat("Error message:", e$message, "\n")
+          }
+        )
+
+        cat("File downloaded and saved as", target_path, "\n")
+      } else {
+        cat("Folder blob, skipping...", target_path, "\n")
+      }
+    }
+  } else {
+    cat("No matching file found for path:", target_path, "\n")
+  }
+})

--- a/scripts/scraper.R
+++ b/scripts/scraper.R
@@ -117,6 +117,6 @@ lapply(pkgs, FUN = function(pkg) {
       }
     }
   } else {
-    cat("No matching file found for path:", target_path, "\n")
+    cat("No matching file found for package:", pkg, "\n")
   }
 })


### PR DESCRIPTION
This PR adds a script for a scraper of the Epidemiology CRAN task view (CTV) packages. Specifically, it identifies and downloads all `man/` and `vignettes/` files (as discussed in #2). The file can be run as a contained `Rscript` in case you have `pkgsearch` and `gh` installed. It will result in a folder called `sources/` that looks something like what we agreed upon in #2:

```
sources
├── <pkg1>
│   ├── man
│   │   ├── ...
│   │   ├── figures
│   │   │   └── ...
│   └── vignettes
│       └── ...
├── <pkg2>
│   ├── man
│   │   └──  ...
│   └── vignettes
│       └── ...
```

My approach for the scraping is to pull all the files off the CRAN mirrors on GitHub. This provides a reliable API, and minimal risk of overburdening an indie maintained server. I understand we did not discuss this choice prior, so I am open to discussing this. I opted for this after I saw that all the packages in the CTV are hosted on CRAN – this may not scale if we are also including Bioconductor or other sources in the future. If we want to opt for another route, I am open to hearing suggestions that would better fullfill our conditions  😊 

## Questions

- At the moment, I download all files regardless of whether they are text or images. Is this desired or do we want to only download text files?
- I slightly altered the proposed folder structure to `<package>/[man|vignettes]/<file>` – is this agreeable or do we want all files in one `<package>/` folder?
- I have not yet built in a limiter to handle rate limits or artificially slow down the scraping. 

## Sample data

I attach a zip file of sample data collected for three packages, as requested by @avinashladdha: [sample_data.zip](https://github.com/user-attachments/files/16545754/sample_data.zip). I am happy to regenerate the sample data if we want to adjust anything on the structure. Currently, the script is set up to only run for the first three packages.

## Reviews

@avinashladdha – I would be grateful to get your feedback on the structure and the sample data, from your perspective on using this content for the model. I also appreciate feedback that go beyond the scraper, which we can resolve at a future time (e.g., are the files themselves in an agreeable format?). 🙌 

@Bisaloo – I would be grateful for your review in its entirety, with the overview you have of the various projects and the technical expertise in R 😊 
